### PR TITLE
Update DatasetMetadata and ReadMe (#2436)

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -1,9 +1,9 @@
 import json
 import logging
 from collections import Counter
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 
 # loading package files: https://stackoverflow.com/a/20885799
@@ -66,7 +66,7 @@ def yaml_block_from_readme(path: Path) -> Optional[str]:
 
 
 def metadata_dict_from_readme(path: Path) -> Optional[Dict[str, List[str]]]:
-    """ "Loads a dataset's metadata from the dataset card (REAMDE.md), as a Python dict"""
+    """Loads a dataset's metadata from the dataset card (REAMDE.md), as a Python dict"""
     yaml_block = yaml_block_from_readme(path=path)
     if yaml_block is None:
         return None
@@ -77,61 +77,126 @@ def metadata_dict_from_readme(path: Path) -> Optional[Dict[str, List[str]]]:
 ValidatorOutput = Tuple[List[str], Optional[str]]
 
 
-def tagset_validator(values: List[str], reference_values: List[str], name: str, url: str) -> ValidatorOutput:
-    invalid_values = [v for v in values if v not in reference_values]
+def tagset_validator(
+    items: Union[List[str], Dict[str, List[str]]],
+    reference_values: List[str],
+    name: str,
+    url: str,
+    escape_validation_predicate_fn: Optional[Callable[[Any], bool]] = None,
+) -> ValidatorOutput:
+    if isinstance(items, list):
+        if escape_validation_predicate_fn is not None:
+            invalid_values = [
+                v for v in items if v not in reference_values and escape_validation_predicate_fn(v) is False
+            ]
+        else:
+            invalid_values = [v for v in items if v not in reference_values]
+
+    else:
+        invalid_values = []
+        if escape_validation_predicate_fn is not None:
+            for config_name, values in items.items():
+                invalid_values += [
+                    v for v in values if v not in reference_values and escape_validation_predicate_fn(v) is False
+                ]
+        else:
+            for config_name, values in items.items():
+                invalid_values += [v for v in values if v not in reference_values]
+
     if len(invalid_values) > 0:
         return [], f"{invalid_values} are not registered tags for '{name}', reference at {url}"
-    return values, None
+    return items, None
 
 
-def escape_validation_for_predicate(
-    values: List[Any], predicate_fn: Callable[[Any], bool]
-) -> Tuple[List[Any], List[Any]]:
-    trues, falses = list(), list()
-    for v in values:
-        if predicate_fn(v):
-            trues.append(v)
+def validate_type(value: Any, expected_type: Type):
+    error_string = ""
+    NoneType = type(None)
+    if expected_type == NoneType:
+        if not isinstance(value, NoneType):
+            return f"Expected `{NoneType}`. Found value: `{value}` of type `{type(value)}`.\n"
         else:
-            falses.append(v)
-    if len(trues) > 0:
-        logger.warning(f"The following values will escape validation: {trues}")
-    return trues, falses
+            return error_string
+    if expected_type == str:
+        if not isinstance(value, str):
+            return f"Expected `{str}`. Found value: `{value}` of type: `{type(value)}`.\n"
+
+        elif isinstance(value, str) and len(value) == 0:
+            return (
+                f"Expected `{str}` with length > 0. Found value: `{value}` of type: `{type(value)}` with length: 0.\n"
+            )
+        else:
+            return error_string
+    # Add more `elif` statements if primitive type checking is needed
+    else:
+        expected_type_origin = expected_type.__origin__
+        expected_type_args = expected_type.__args__
+
+        if expected_type_origin == Union:
+            for type_arg in expected_type_args:
+                temp_error_string = validate_type(value, type_arg)
+                if temp_error_string == "":  # at least one type is successfully validated
+                    return temp_error_string
+                else:
+                    if error_string == "":
+                        error_string = "(" + temp_error_string + ")"
+                    else:
+                        error_string += "\nOR\n" + "(" + temp_error_string + ")"
+
+        else:
+            # Assuming `List`/`Dict`/`Tuple`
+            if not isinstance(value, expected_type_origin) or len(value) == 0:
+                return f"Expected `{expected_type_origin}` with length > 0. Found value of type: `{type(value)}`, with length: {len(value)}.\n"
+
+            if expected_type_origin == Dict:
+                key_type, value_type = expected_type_args
+                key_error_string = ""
+                value_error_string = ""
+                for k, v in value.items():
+                    key_error_string += validate_type(k, key_type)
+                    value_error_string += validate_type(v, value_type)
+                if key_error_string != "" or value_error_string != "":
+                    return f"Typing errors with keys:\n {key_error_string} and values:\n {value_error_string}"
+
+            else:  # `List`/`Tuple`
+                value_type = expected_type_args[0]
+                value_error_string = ""
+                for v in value:
+                    value_error_string += validate_type(v, value_type)
+                if value_error_string != "":
+                    return f"Typing errors with values:\n {value_error_string}"
+
+        return error_string
 
 
 def validate_metadata_type(metadata_dict: dict):
-    fields_types = {field.name: field.type for field in fields(DatasetMetadata)}
-    list_typing_errors = {
-        name: value
-        for name, value in metadata_dict.items()
-        if fields_types.get(name, List[str]) == List[str]
-        and (not isinstance(value, list) or len(value) == 0 or not isinstance(value[0], str))
-    }
-    if len(list_typing_errors) > 0:
-        raise TypeError(f"Found fields that are not non-empty list of strings: {list_typing_errors}")
+    field_types = {field.name: field.type for field in fields(DatasetMetadata)}
 
-    other_typing_errors = {
-        name: value
-        for name, value in metadata_dict.items()
-        if fields_types.get(name, List[str]) != List[str] and isinstance(value, list)
-    }
-    if len(other_typing_errors) > 0:
-        raise TypeError(f"Found fields that are lists instead of single strings: {other_typing_errors}")
+    typing_errors = {}
+    for field_name, field_value in metadata_dict.items():
+        field_type_error = validate_type(
+            metadata_dict[field_name], field_types.get(field_name, Union[List[str], Dict[str, List[str]]])
+        )
+        if field_type_error != "":
+            typing_errors[field_name] = field_type_error
+    if len(typing_errors) > 0:
+        raise TypeError(f"The following typing errors are found: {typing_errors}")
 
 
 @dataclass
 class DatasetMetadata:
-    annotations_creators: List[str]
-    language_creators: List[str]
-    languages: List[str]
-    licenses: List[str]
-    multilinguality: List[str]
-    size_categories: List[str]
-    source_datasets: List[str]
-    task_categories: List[str]
-    task_ids: List[str]
+    annotations_creators: Union[List[str], Dict[str, List[str]]]
+    language_creators: Union[List[str], Dict[str, List[str]]]
+    languages: Union[List[str], Dict[str, List[str]]]
+    licenses: Union[List[str], Dict[str, List[str]]]
+    multilinguality: Union[List[str], Dict[str, List[str]]]
+    pretty_name: Union[str, Dict[str, str]]
+    size_categories: Union[List[str], Dict[str, List[str]]]
+    source_datasets: Union[List[str], Dict[str, List[str]]]
+    task_categories: Union[List[str], Dict[str, List[str]]]
+    task_ids: Union[List[str], Dict[str, List[str]]]
     paperswithcode_id: Optional[str] = None
 
-    def __post_init__(self):
+    def validate(self):
         validate_metadata_type(metadata_dict=vars(self))
 
         self.annotations_creators, annotations_creators_errors = self.validate_annotations_creators(
@@ -168,7 +233,7 @@ class DatasetMetadata:
                 exception_msg_dict[field] = errs
         if len(exception_msg_dict) > 0:
             raise TypeError(
-                "Could not validate the metada, found the following errors:\n"
+                "Could not validate the metadata, found the following errors:\n"
                 + "\n".join(f"* field '{fieldname}':\n\t{err}" for fieldname, err in exception_msg_dict.items())
             )
 
@@ -190,7 +255,7 @@ class DatasetMetadata:
         if yaml_string is not None:
             return cls.from_yaml_string(yaml_string)
         else:
-            raise TypeError(f"did not find a yaml block in '{path}'")
+            raise TypeError(f"Unable to find a yaml block in '{path}'")
 
     @classmethod
     def from_yaml_string(cls, string: str) -> "DatasetMetadata":
@@ -206,24 +271,20 @@ class DatasetMetadata:
             :obj:`TypeError`: If the dataset's metadata is invalid
         """
         metada_dict = yaml.load(string, Loader=NoDuplicateSafeLoader) or dict()
-        # flatten the metadata of each config
-        for key in metada_dict:
-            if isinstance(metada_dict[key], dict):
-                metada_dict[key] = list(set(sum(metada_dict[key].values(), [])))
         return cls(**metada_dict)
 
     @staticmethod
-    def validate_annotations_creators(annotations_creators: List[str]) -> ValidatorOutput:
+    def validate_annotations_creators(annotations_creators: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         return tagset_validator(
             annotations_creators, known_creators["annotations"], "annotations_creators", known_creators_url
         )
 
     @staticmethod
-    def validate_language_creators(language_creators: List[str]) -> ValidatorOutput:
+    def validate_language_creators(language_creators: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         return tagset_validator(language_creators, known_creators["language"], "language_creators", known_creators_url)
 
     @staticmethod
-    def validate_language_codes(languages: List[str]) -> ValidatorOutput:
+    def validate_language_codes(languages: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         return tagset_validator(
             values=languages,
             reference_values=known_language_codes.keys(),
@@ -232,47 +293,53 @@ class DatasetMetadata:
         )
 
     @staticmethod
-    def validate_licences(licenses: List[str]) -> ValidatorOutput:
-        others, to_validate = escape_validation_for_predicate(
-            licenses, lambda e: "-other-" in e or e.startswith("other-")
+    def validate_licences(licenses: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
+        validated, error = tagset_validator(
+            licenses,
+            list(known_licenses.keys()),
+            "licenses",
+            known_licenses_url,
+            lambda e: "-other-" in e or e.startswith("other-"),
         )
-        validated, error = tagset_validator(to_validate, list(known_licenses.keys()), "licenses", known_licenses_url)
-        return [*validated, *others], error
+        return validated, error
 
     @staticmethod
-    def validate_task_categories(task_categories: List[str]) -> ValidatorOutput:
+    def validate_task_categories(task_categories: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         # TODO: we're currently ignoring all values starting with 'other' as our task taxonomy is bound to change
         #   in the near future and we don't want to waste energy in tagging against a moving taxonomy.
         known_set = list(known_task_ids.keys())
-        others, to_validate = escape_validation_for_predicate(task_categories, lambda e: e.startswith("other-"))
-        validated, error = tagset_validator(to_validate, known_set, "task_categories", known_task_ids_url)
-        return [*validated, *others], error
+        validated, error = tagset_validator(
+            task_categories, known_set, "task_categories", known_task_ids_url, lambda e: e.startswith("other-")
+        )
+        return validated, error
 
     @staticmethod
-    def validate_task_ids(task_ids: List[str]) -> ValidatorOutput:
+    def validate_task_ids(task_ids: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         # TODO: we're currently ignoring all values starting with 'other' as our task taxonomy is bound to change
         #   in the near future and we don't want to waste energy in tagging against a moving taxonomy.
         known_set = [tid for _cat, d in known_task_ids.items() for tid in d["options"]]
-        others, to_validate = escape_validation_for_predicate(
-            task_ids, lambda e: "-other-" in e or e.startswith("other-")
-        )
-        validated, error = tagset_validator(to_validate, known_set, "task_ids", known_task_ids_url)
-        return [*validated, *others], error
-
-    @staticmethod
-    def validate_mulitlinguality(multilinguality: List[str]) -> ValidatorOutput:
-        others, to_validate = escape_validation_for_predicate(multilinguality, lambda e: e.startswith("other-"))
         validated, error = tagset_validator(
-            to_validate, list(known_multilingualities.keys()), "multilinguality", known_size_categories_url
+            task_ids, known_set, "task_ids", known_task_ids_url, lambda e: "-other-" in e or e.startswith("other-")
         )
-        return [*validated, *others], error
+        return validated, error
 
     @staticmethod
-    def validate_size_catgeories(size_cats: List[str]) -> ValidatorOutput:
+    def validate_mulitlinguality(multilinguality: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
+        validated, error = tagset_validator(
+            multilinguality,
+            list(known_multilingualities.keys()),
+            "multilinguality",
+            known_size_categories_url,
+            lambda e: e.startswith("other-"),
+        )
+        return validated, error
+
+    @staticmethod
+    def validate_size_catgeories(size_cats: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         return tagset_validator(size_cats, known_size_categories, "size_categories", known_size_categories_url)
 
     @staticmethod
-    def validate_source_datasets(sources: List[str]) -> ValidatorOutput:
+    def validate_source_datasets(sources: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
         invalid_values = []
         for src in sources:
             is_ok = src in ["original", "extended"] or src.startswith("extended|")
@@ -299,6 +366,48 @@ class DatasetMetadata:
             else:
                 return paperswithcode_id, None
 
+    @staticmethod
+    def validate_pretty_name(pretty_name: Union[str, Dict[str, str]]):
+        if isinstance(pretty_name, str):
+            if len(pretty_name) == 0:
+                return None, f"The pretty name must have a length greater than 0 but got an empty string."
+        else:
+            error_string = ""
+            for key, value in pretty_name.items():
+                if len(value) == 0:
+                    error_string += f"The pretty name must have a length greater than 0 but got an empty string for config: {key}.\n"
+
+            if error_string == "":
+                return None, error_string
+            else:
+                return pretty_name, None
+
+    def get_metadata_by_config_name(self, name: str) -> "DatasetMetadata":
+        metadata_dict = asdict(self)
+        config_name_hit = []
+        has_multi_configs = []
+        result_dict = {}
+        for tag_key, tag_value in metadata_dict.items():
+            if isinstance(tag_value, str) or isinstance(tag_value, list):
+                result_dict[tag_key] = tag_value
+            elif isinstance(tag_value, dict):
+                has_multi_configs.append(tag_key)
+                for config_name, value in tag_value.items():
+                    if config_name == name:
+                        result_dict[tag_key] = value
+                        config_name_hit.append(tag_key)
+
+        if len(has_multi_configs) > 0 and has_multi_configs != config_name_hit:
+            raise TypeError(
+                f"The following tags have multiple configs: {has_multi_configs} but the config `{name}`  was found only in: {config_name_hit}."
+            )
+        if config_name_hit == 0:
+            logger.warning(
+                "No matching config names found in the metadata, using the common values to create metadata."
+            )
+
+        return DatasetMetadata(**result_dict)
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
@@ -308,4 +417,5 @@ if __name__ == "__main__":
     args = ap.parse_args()
 
     readme_filepath = Path(args.readme_filepath)
-    DatasetMetadata.from_readme(readme_filepath)
+    dataset_metadata = DatasetMetadata.from_readme(readme_filepath)
+    dataset_metadata.validate()

--- a/src/datasets/utils/readme.py
+++ b/src/datasets/utils/readme.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Tuple
 
@@ -38,22 +37,20 @@ FILLER_TEXT = [
 ReadmeValidatorOutput = Tuple[dict, List[str], List[str]]
 
 
-@dataclass
 class Section:
-    name: str
-    level: str
-    lines: List[str] = None
-
-    def __post_init__(self):
+    def __init__(self, name: str, level: str, lines: List[str] = None, suppress_parsing_errors: bool = False):
+        self.name = name
+        self.level = level
+        self.lines = lines
         self.text = ""
         self.is_empty_text = True
         self.content = {}
         self.parsing_error_list = []
         self.parsing_warning_list = []
         if self.lines is not None:
-            self.parse()
+            self.parse(suppress_parsing_errors=suppress_parsing_errors)
 
-    def parse(self):
+    def parse(self, suppress_parsing_errors: bool = False):
         current_sub_level = ""
         current_lines = []
         code_start = False
@@ -88,6 +85,12 @@ class Section:
                     self.text += "".join(current_lines).strip()
                     if self.text != "" and self.text not in FILLER_TEXT:
                         self.is_empty_text = False
+
+        if self.level == "" and not suppress_parsing_errors:
+            if self.parsing_error_list != [] or self.parsing_warning_list != []:
+                errors = errors = "\n".join("-\t" + x for x in self.parsing_error_list + self.parsing_warning_list)
+                error_string = f"The following issues were found while parsing the README at `{self.name}`:\n" + errors
+                raise ValueError(error_string)
 
     def validate(self, structure: dict) -> ReadmeValidatorOutput:
         """Validates a Section class object recursively using the structure provided as a dictionary.
@@ -151,8 +154,6 @@ class Section:
                         warning_list.append(
                             f"`{self.name}` has an extra subsection: `{name}`. Skipping further validation checks for this subsection as expected structure is unknown."
                         )
-        error_list = self.parsing_error_list + error_list
-        warning_list = self.parsing_warning_list + warning_list
         if error_list:
             # If there are errors, do not return the dictionary as it is invalid
             return {}, error_list, warning_list
@@ -170,40 +171,39 @@ class Section:
 
 
 class ReadMe(Section):  # Level 0
-    def __init__(self, name: str, lines: List[str], structure: dict = None):
+    def __init__(self, name: str, lines: List[str], structure: dict = None, suppress_parsing_errors: bool = False):
         super().__init__(name=name, level="")  # Not using lines here as we need to use a child class parse
         self.structure = structure
         self.yaml_tags_line_count = -2
         self.tag_count = 0
         self.lines = lines
         if self.lines is not None:
-            self.parse()
+            self.parse(suppress_parsing_errors=suppress_parsing_errors)
 
-        # Validation
+    def validate(self):
         if self.structure is None:
-            content, error_list, warning_list = self.validate(readme_structure)
+            content, error_list, warning_list = self._validate(readme_structure)
         else:
-            content, error_list, warning_list = self.validate(self.structure)
-
-        error_list = self.parsing_error_list + error_list
-        warning_list = self.parsing_warning_list + warning_list
+            content, error_list, warning_list = self._validate(self.structure)
         if error_list != [] or warning_list != []:
             errors = "\n".join(list(map(lambda x: "-\t" + x, error_list + warning_list)))
             error_string = f"The following issues were found for the README at `{self.name}`:\n" + errors
             raise ValueError(error_string)
 
     @classmethod
-    def from_readme(cls, path: Path, structure: dict = None):
+    def from_readme(cls, path: Path, structure: dict = None, suppress_parsing_errors: bool = False):
         with open(path, encoding="utf-8") as f:
             lines = f.readlines()
-        return cls(path, lines, structure)
+        return cls(path, lines, structure, suppress_parsing_errors=suppress_parsing_errors)
 
     @classmethod
-    def from_string(cls, string: str, structure: dict = None, root_name: str = "root"):
+    def from_string(
+        cls, string: str, structure: dict = None, root_name: str = "root", suppress_parsing_errors: bool = False
+    ):
         lines = string.split("\n")
-        return cls(root_name, lines, structure)
+        return cls(root_name, lines, structure, suppress_parsing_errors=suppress_parsing_errors)
 
-    def parse(self):
+    def parse(self, suppress_parsing_errors: bool = False):
         # Skip Tags
         line_count = 0
 
@@ -218,13 +218,13 @@ class ReadMe(Section):  # Level 0
             self.lines = self.lines[line_count + 1 :]  # Get the last + 1 th item.
         else:
             self.lines = self.lines[self.tag_count :]
-        super().parse()
+        super().parse(suppress_parsing_errors=suppress_parsing_errors)
 
     def __str__(self):
         """Returns the string of dictionary representation of the ReadMe."""
         return str(self.to_dict())
 
-    def validate(self, readme_structure):
+    def _validate(self, readme_structure):
         error_list = []
         warning_list = []
         if self.yaml_tags_line_count == 0:

--- a/tests/test_dataset_cards.py
+++ b/tests/test_dataset_cards.py
@@ -56,11 +56,21 @@ def test_changed_dataset_card(dataset_name):
     assert card_path.exists()
     error_messages = []
     try:
-        ReadMe.from_readme(card_path)
-    except Exception as readme_error:
-        error_messages.append(f"The following issues have been found in the dataset cards:\nREADME:\n{readme_error}")
+        readme = ReadMe.from_readme(card_path)
+    except Exception as readme_parsing_error:
+        error_messages.append(
+            f"The following issues have been found in the dataset cards:\nREADME Parsing:\n{readme_parsing_error}"
+        )
     try:
-        DatasetMetadata.from_readme(card_path)
+        readme = ReadMe.from_readme(card_path, suppress_parsing_errors=True)
+        readme.validate()
+    except Exception as readme_validation_error:
+        error_messages.append(
+            f"The following issues have been found in the dataset cards:\nREADME Validation:\n{readme_validation_error}"
+        )
+    try:
+        metadata = DatasetMetadata.from_readme(card_path)
+        metadata.validate()
     except Exception as metadata_error:
         error_messages.append(
             f"The following issues have been found in the dataset cards:\nYAML tags:\n{metadata_error}"
@@ -77,11 +87,21 @@ def test_dataset_card(dataset_name):
     assert card_path.exists()
     error_messages = []
     try:
-        ReadMe.from_readme(card_path)
-    except Exception as readme_error:
-        error_messages.append(f"The following issues have been found in the dataset cards:\nREADME:\n{readme_error}")
+        readme = ReadMe.from_readme(card_path)
+    except Exception as readme_parsing_error:
+        error_messages.append(
+            f"The following issues have been found in the dataset cards:\nREADME Parsing:\n{readme_parsing_error}"
+        )
     try:
-        DatasetMetadata.from_readme(card_path)
+        readme = ReadMe.from_readme(card_path, suppress_parsing_errors=True)
+        readme.validate()
+    except Exception as readme_validation_error:
+        error_messages.append(
+            f"The following issues have been found in the dataset cards:\nREADME Validation:\n{readme_validation_error}"
+        )
+    try:
+        metadata = DatasetMetadata.from_readme(card_path)
+        metadata.validate()
     except Exception as metadata_error:
         error_messages.append(
             f"The following issues have been found in the dataset cards:\nYAML tags:\n{metadata_error}"

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -1,11 +1,11 @@
 import re
 import tempfile
 import unittest
+from dataclasses import asdict
 from pathlib import Path
 
 from datasets.utils.metadata import (
     DatasetMetadata,
-    escape_validation_for_predicate,
     metadata_dict_from_readme,
     tagset_validator,
     validate_metadata_type,
@@ -53,7 +53,8 @@ class TestMetadataUtils(unittest.TestCase):
             "tag": ["list", "of", "values"],
             "another tag": ["Another", {"list"}, ["of"], 0x646D46736457567A],
         }
-        validate_metadata_type(metadata_dict)
+        with self.assertRaises(TypeError):
+            validate_metadata_type(metadata_dict)
 
         metadata_dict = {"tag1": []}
         with self.assertRaises(TypeError):
@@ -67,48 +68,68 @@ class TestMetadataUtils(unittest.TestCase):
         name = "test_tag"
         url = "https://dummy.hf.co"
 
-        values = ["tag1", "tag2", "tag2", "tag3"]
+        items = ["tag1", "tag2", "tag2", "tag3"]
         reference_values = ["tag1", "tag2", "tag3"]
-        returned_values, error = tagset_validator(values=values, reference_values=reference_values, name=name, url=url)
-        self.assertListEqual(returned_values, values)
+        returned_values, error = tagset_validator(items=items, reference_values=reference_values, name=name, url=url)
+        self.assertListEqual(returned_values, items)
         self.assertIsNone(error)
 
-        values = []
+        items = []
         reference_values = ["tag1", "tag2", "tag3"]
-        returned_values, error = tagset_validator(values=values, reference_values=reference_values, name=name, url=url)
-        self.assertListEqual(returned_values, values)
+        items, error = tagset_validator(items=items, reference_values=reference_values, name=name, url=url)
+        self.assertListEqual(items, [])
         self.assertIsNone(error)
 
-        values = []
+        items = []
         reference_values = []
-        returned_values, error = tagset_validator(values=values, reference_values=reference_values, name=name, url=url)
-        self.assertListEqual(returned_values, values)
+        returned_values, error = tagset_validator(items=items, reference_values=reference_values, name=name, url=url)
+        self.assertListEqual(returned_values, [])
         self.assertIsNone(error)
 
-        values = ["tag1", "tag2", "tag2", "tag3", "unknown tag"]
+        items = ["tag1", "tag2", "tag2", "tag3", "unknown tag"]
         reference_values = ["tag1", "tag2", "tag3"]
-        returned_values, error = tagset_validator(values=values, reference_values=reference_values, name=name, url=url)
+        returned_values, error = tagset_validator(items=items, reference_values=reference_values, name=name, url=url)
         self.assertListEqual(returned_values, [])
         self.assertEqual(error, f"{['unknown tag']} are not registered tags for '{name}', reference at {url}")
 
-    def test_escape_validation_for_predicate(self):
-        def predicate_fn(string: str) -> bool:
+        def predicate_fn(string):
             return "ignore" in string
 
-        values = ["process me", "process me too", "ignore me"]
-        to_ignore, to_validate = escape_validation_for_predicate(values=values, predicate_fn=predicate_fn)
-        self.assertListEqual(to_ignore, ["ignore me"])
-        self.assertListEqual(to_validate, ["process me", "process me too"])
+        items = ["process me", "process me too", "ignore me"]
+        reference_values = ["process me too"]
+        returned_values, error = tagset_validator(
+            items=items,
+            reference_values=reference_values,
+            name=name,
+            url=url,
+            escape_validation_predicate_fn=predicate_fn,
+        )
+        self.assertListEqual(returned_values, [])
+        self.assertEqual(error, f"{['process me']} are not registered tags for '{name}', reference at {url}")
 
-        values = ["process me", "process me too"]
-        to_ignore, to_validate = escape_validation_for_predicate(values=values, predicate_fn=predicate_fn)
-        self.assertListEqual(to_ignore, [])
-        self.assertListEqual(to_validate, values)
+        items = ["process me", "process me too", "ignore me"]
+        reference_values = ["process me too", "process me"]
+        returned_values, error = tagset_validator(
+            items=items,
+            reference_values=reference_values,
+            name=name,
+            url=url,
+            escape_validation_predicate_fn=predicate_fn,
+        )
+        self.assertListEqual(returned_values, items)
+        self.assertIsNone(error)
 
-        values = ["this value will be ignored", "ignore this one two"]
-        to_ignore, to_validate = escape_validation_for_predicate(values=values, predicate_fn=predicate_fn)
-        self.assertListEqual(to_ignore, values)
-        self.assertListEqual(to_validate, [])
+        items = ["ignore me too", "ignore me"]
+        reference_values = ["process me too"]
+        returned_values, error = tagset_validator(
+            items=items,
+            reference_values=reference_values,
+            name=name,
+            url=url,
+            escape_validation_predicate_fn=predicate_fn,
+        )
+        self.assertListEqual(returned_values, items)
+        self.assertIsNone(error)
 
     def test_yaml_block_from_readme(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -177,6 +198,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -204,6 +226,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -228,6 +251,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -239,7 +263,8 @@ class TestMetadataUtils(unittest.TestCase):
             """
         )
         with self.assertRaises(TypeError):
-            DatasetMetadata.from_yaml_string(invalid_tag_yaml)
+            metadata = DatasetMetadata.from_yaml_string(invalid_tag_yaml)
+            metadata.validate()
 
         missing_tag_yaml = _dedent(
             """\
@@ -251,6 +276,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -262,7 +288,8 @@ class TestMetadataUtils(unittest.TestCase):
             """
         )
         with self.assertRaises(TypeError):
-            DatasetMetadata.from_yaml_string(missing_tag_yaml)
+            metadata = DatasetMetadata.from_yaml_string(missing_tag_yaml)
+            metadata.validate()
 
         duplicate_yaml_keys = _dedent(
             """\
@@ -274,6 +301,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -287,7 +315,8 @@ class TestMetadataUtils(unittest.TestCase):
             """
         )
         with self.assertRaises(TypeError):
-            DatasetMetadata.from_yaml_string(duplicate_yaml_keys)
+            metadata = DatasetMetadata.from_yaml_string(duplicate_yaml_keys)
+            metadata.validate()
 
         valid_yaml_string_with_duplicate_configs = _dedent(
             """\
@@ -304,6 +333,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -315,7 +345,8 @@ class TestMetadataUtils(unittest.TestCase):
             """
         )
         with self.assertRaises(TypeError):
-            DatasetMetadata.from_yaml_string(valid_yaml_string_with_duplicate_configs)
+            metadata = DatasetMetadata.from_yaml_string(valid_yaml_string_with_duplicate_configs)
+            metadata.validate()
 
         valid_yaml_string_with_paperswithcode_id = _dedent(
             """\
@@ -329,6 +360,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -354,6 +386,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -379,6 +412,7 @@ class TestMetadataUtils(unittest.TestCase):
             - unknown
             multilinguality:
             - monolingual
+            pretty_name: Test Dataset
             size_categories:
             - 10K<n<100K
             source_datasets:
@@ -392,4 +426,202 @@ class TestMetadataUtils(unittest.TestCase):
             """
         )
         with self.assertRaises(TypeError):
-            DatasetMetadata.from_yaml_string(valid_yaml_string_with_list_paperswithcode_id)
+            metadata = DatasetMetadata.from_yaml_string(valid_yaml_string_with_list_paperswithcode_id)
+            metadata.validate()
+
+    def test_get_metadata_by_config_name(self):
+        valid_yaml_with_multiple_configs = _dedent(
+            """\
+            annotations_creators:
+            - found
+            language_creators:
+            - found
+            languages:
+              en:
+              - en
+              fr:
+              - fr
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            pretty_name:
+              en: English Test Dataset
+              fr: French Test Dataset
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            paperswithcode_id:
+            - squad
+            """
+        )
+
+        metadata = DatasetMetadata.from_yaml_string(valid_yaml_with_multiple_configs)
+        en_metadata = metadata.get_metadata_by_config_name("en")
+        self.assertEqual(
+            asdict(en_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["en"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "English Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+        fr_metadata = metadata.get_metadata_by_config_name("fr")
+        self.assertEqual(
+            asdict(fr_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["fr"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "French Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+
+        valid_yaml_with_single_configs = _dedent(
+            """\
+            annotations_creators:
+            - found
+            language_creators:
+            - found
+            languages:
+            - en
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            pretty_name: Test Dataset
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            paperswithcode_id:
+            - squad
+            """
+        )
+
+        metadata = DatasetMetadata.from_yaml_string(valid_yaml_with_single_configs)
+        en_metadata = metadata.get_metadata_by_config_name("en")
+        self.assertEqual(
+            asdict(en_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["en"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+        fr_metadata = metadata.get_metadata_by_config_name("fr")
+        self.assertEqual(
+            asdict(fr_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["en"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+
+        invalid_yaml_with_multiple_configs = _dedent(
+            """\
+            annotations_creators:
+            - found
+            language_creators:
+            - found
+            languages:
+              en:
+              - en
+              zh:
+              - zh
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            pretty_name: Test Dataset
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            paperswithcode_id:
+            - squad
+            """
+        )
+
+        metadata = DatasetMetadata.from_yaml_string(invalid_yaml_with_multiple_configs)
+        en_metadata = metadata.get_metadata_by_config_name("en")
+        self.assertEqual(
+            asdict(en_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["en"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+        zh_metadata = metadata.get_metadata_by_config_name("zh")
+        self.assertEqual(
+            asdict(zh_metadata),
+            {
+                "annotations_creators": ["found"],
+                "language_creators": ["found"],
+                "languages": ["zh"],
+                "licenses": ["unknown"],
+                "multilinguality": ["monolingual"],
+                "pretty_name": "Test Dataset",
+                "size_categories": ["10K<n<100K"],
+                "source_datasets": ["extended|other-yahoo-webscope-l6"],
+                "task_categories": ["question-answering"],
+                "task_ids": ["open-domain-qa"],
+                "paperswithcode_id": ["squad"],
+            },
+        )
+        with self.assertRaises(TypeError):
+            fr_metadata = metadata.get_metadata_by_config_name("fr")


### PR DESCRIPTION
* Update tagset validator to allow dict

* Add escape validation mask for predicate_fn

* Add recursive metadata type checking

* Update typing errors validation

* Update input types in validation methods

* Add method to get metadata by config

* Fix styling/typing issues

* Simplify predicate_fn in validation

* Fix existing tests

* Add test for get metadata by config name

* Update test dataset cards

* Fix style

* Fix style

* Support `validate` method in ReadMe

* Add changes from review